### PR TITLE
add support to return html when rich_text carbon fields

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -116,7 +116,7 @@ class Field
     }
   }
 
-  private function getCrbType()
+  public function getCrbType()
   {
     return $this->field->get_type();
   }

--- a/src/MetaResolver.php
+++ b/src/MetaResolver.php
@@ -10,7 +10,14 @@ class MetaResolver
 {
   public static function getScalar($value, Field $field, Container $container, $args = null, AppContext $context = null, ResolveInfo $info = null)
   {
-    return $value;
+    switch ($field->getCrbType()) {
+      case 'rich_text':
+        return apply_filters('the_content', $value);
+      
+      default:
+        return $value;
+    }
+
   }
 
   public static function getFloat($value, Field $field, Container $container, $args, AppContext $context, ResolveInfo $info)


### PR DESCRIPTION
Before this commit, a rich text field queried via graphql would return a string like:

```
first paragraph
\r\n\r\n
second paragraph
```

From now on, it will return a HTML parsed string:
```
<p>first paragraph</p>
\n
<p>second paragraph</p>
```